### PR TITLE
Locked renderer during `Mat::NextState()`

### DIFF
--- a/ZED/include/renderer.h
+++ b/ZED/include/renderer.h
@@ -276,7 +276,7 @@ namespace ZED
 	private:
 		DLLEXPORT static Renderer* s_pInstance;
 
-		mutable std::mutex m_mutex;
+		mutable std::recursive_mutex m_mutex;
 	};
 
 

--- a/src/mat.cpp
+++ b/src/mat.cpp
@@ -1192,6 +1192,7 @@ void Mat::NextState(State NextState) const
 	const int effect_row3 = effect_row2 + (int)(96.0 * m_ScalingFactor);
 
 	auto& renderer = m_Window.GetRenderer();
+	renderer.Lock();
 
 	switch (m_State)
 	{
@@ -1455,6 +1456,8 @@ void Mat::NextState(State NextState) const
 			m_Graphics["winner_white"].AddAnimation(Animation::CreateLinear(0.0, 0.0, -40.0));
 			break;
 	}
+
+	renderer.Unlock();
 }
 
 

--- a/src/mat.cpp
+++ b/src/mat.cpp
@@ -126,6 +126,8 @@ bool Mat::Close()
 
 bool Mat::Reset()
 {
+	m_mutex.lock();
+
 	if (AreFightersOnMat())
 	{
 		ZED::Log::Warn("Can not reset match, the previous match is still ongoing");
@@ -146,6 +148,8 @@ bool Mat::Reset()
 	m_IsDraw = false;
 
 	m_pMatch = nullptr;
+
+	m_mutex.unlock();
 
 	ZED::Log::Info("Mat got resetted");
 	return true;
@@ -226,11 +230,12 @@ bool Mat::EndMatch()
 			m_pMatch->EndMatch();
 		}
 		
+		m_mutex.unlock();
+
 		//Reset mat
 		NextState(State::TransitionToWaiting);
 
 		Reset();
-		m_mutex.unlock();
 
 		ZED::Log::Debug("Match ended");
 

--- a/src/mat.cpp
+++ b/src/mat.cpp
@@ -191,14 +191,14 @@ bool Mat::StartMatch(Match* NewMatch)
 		return false;
 	}
 
-	m_mutex.lock();
-
 	if (!Reset())
 	{
 		ZED::Log::Warn("Could not reset mat");
 		m_mutex.unlock();
 		return false;
 	}
+
+	m_mutex.lock();
 
 	m_White = *NewMatch->GetFighter(Fighter::White);
 	m_Blue  = *NewMatch->GetFighter(Fighter::Blue);
@@ -207,9 +207,10 @@ bool Mat::StartMatch(Match* NewMatch)
 
 	NewMatch->StartMatch();
 	AddEvent(MatchLog::NeutralEvent::StartMatch);
-	NextState(State::TransitionToMatch);
 
 	m_mutex.unlock();
+
+	NextState(State::TransitionToMatch);
 
 	ZED::Log::Debug("New match started");
 	return true;

--- a/src/mat.h
+++ b/src/mat.h
@@ -429,7 +429,7 @@ namespace Judoboard
 		uint32_t m_LastFrameTime = 40;
 
 		std::thread m_Thread;//Thread for running the main loop
-		mutable std::mutex m_mutex;
+		mutable std::recursive_mutex m_mutex;
 
 		//Graphics
 		mutable std::unordered_map<std::string, GraphicElement> m_Graphics;


### PR DESCRIPTION
This should fix a crash (race condition) during end match